### PR TITLE
feat: provide pdftex compatibility for luatex

### DIFF
--- a/IPLeiriaReport.cls
+++ b/IPLeiriaReport.cls
@@ -63,6 +63,9 @@
 \colorlet{darkred}{red!50!black}
 \definecolor{frontpagedark}{HTML}{1c1c1c}
 
+% Provide pdfTeX compatibility for LuaTeX
+\RequirePackage{luatex85} 
+
 % Margins
 \usepackage[
 	top=2.5cm, % Top margin


### PR DESCRIPTION
Ao tentar compilar com luatex usando este commando bash abaixo o pdf não formatava corretamente na capa:

```sh
lualatex -synctex=1 -interaction=nonstopmode -shell-escape IPLeiriaMain.tex
```
Ao adicionar a seguinte linha no ficheiro `IPLeiriaReport.cls` já compila com sucesso:

```tex
% ./IPLeiriaReport.cls

\RequirePackage{luatex85} 
```
